### PR TITLE
Update existing managed objects instead of creating new ones

### DIFF
--- a/EasyMapping/EKManagedObjectMapping.h
+++ b/EasyMapping/EKManagedObjectMapping.h
@@ -13,6 +13,7 @@
 @interface EKManagedObjectMapping : EKObjectMapping
 
 @property (nonatomic, assign, readonly) NSString* entityName;
+@property (nonatomic, assign) NSString *primaryKey;
 
 + (EKManagedObjectMapping *)mappingForEntityName:(NSString *)entityName
                                        withBlock:(void(^)(EKManagedObjectMapping *mapping))mappingBlock;

--- a/EasyMappingCoreDataExample/Car.h
+++ b/EasyMappingCoreDataExample/Car.h
@@ -12,6 +12,7 @@
 
 @interface Car : NSManagedObject
 
+@property (nonatomic, retain) NSNumber * carID;
 @property (nonatomic, retain) NSString * model;
 @property (nonatomic, retain) NSString * year;
 @property (nonatomic, retain) NSDate * createdAt;

--- a/EasyMappingCoreDataExample/Car.m
+++ b/EasyMappingCoreDataExample/Car.m
@@ -11,6 +11,7 @@
 
 @implementation Car
 
+@dynamic carID;
 @dynamic model;
 @dynamic year;
 @dynamic createdAt;

--- a/EasyMappingCoreDataExample/EasyMappingCoreDataExample.xcdatamodeld/EasyMappingCoreDataExample.xcdatamodel/contents
+++ b/EasyMappingCoreDataExample/EasyMappingCoreDataExample.xcdatamodeld/EasyMappingCoreDataExample.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model name="" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="2061" systemVersion="12D78" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Car" representedClassName="Car" syncable="YES">
+        <attribute name="carID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="model" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="year" optional="YES" attributeType="String" syncable="YES"/>
@@ -10,6 +11,7 @@
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="gender" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="personID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <relationship name="car" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Car" inverseName="person" inverseEntity="Car" syncable="YES"/>
         <relationship name="phones" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Phone" inverseName="person" inverseEntity="Phone" syncable="YES"/>
     </entity>
@@ -17,11 +19,12 @@
         <attribute name="ddd" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="ddi" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="phoneID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <relationship name="person" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Person" inverseName="phones" inverseEntity="Person" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Car" positionX="160" positionY="192" width="128" height="105"/>
-        <element name="Person" positionX="54" positionY="-99" width="128" height="120"/>
-        <element name="Phone" positionX="-279" positionY="9" width="128" height="105"/>
+        <element name="Car" positionX="160" positionY="192" width="128" height="120"/>
+        <element name="Person" positionX="160" positionY="192" width="128" height="135"/>
+        <element name="Phone" positionX="160" positionY="192" width="128" height="120"/>
     </elements>
 </model>

--- a/EasyMappingCoreDataExample/EasyMappingCoreDataExampleTests/EKManagedObjectMapperSpec.m
+++ b/EasyMappingCoreDataExample/EasyMappingCoreDataExampleTests/EKManagedObjectMapperSpec.m
@@ -68,6 +68,56 @@ describe(@"EKManagedObjectMapper", ^{
             
         });
         
+        context(@"with existing object", ^{
+            
+            __block NSManagedObjectContext* moc;
+            __block Car *oldCar;
+            __block Car *car;
+            __block NSDictionary *externalRepresentation;
+            
+            beforeEach(^{
+                moc = [NSManagedObjectContext MR_defaultContext];
+                
+                oldCar = [NSEntityDescription insertNewObjectForEntityForName:@"Car" inManagedObjectContext:moc];
+                oldCar.carID = @(1);
+                oldCar.year = @"1980";
+                oldCar.model = @"";
+                [moc MR_saveToPersistentStoreAndWait];
+                
+                externalRepresentation = @{
+                    @"id": @(1),
+                    @"model": @"i30",
+                    @"year": @"2013"
+                };
+                
+                car = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider carMapping] inManagedObjectContext:moc];
+            });
+            
+            specify(^{
+                [car shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[car should] equal:oldCar];
+            });
+            
+            specify(^{
+                [[car.carID should] equal:oldCar.carID];
+            });
+            
+            specify(^{
+                [[car.model should] equal:[externalRepresentation objectForKey:@"model"]];
+            });
+            
+            specify(^{
+                [[car.year should] equal:[externalRepresentation objectForKey:@"year"]];
+            });
+            
+            specify(^{
+                [[[Car MR_findAll] should] haveCountOf:1];
+            });
+        });
+        
         context(@"with root key", ^{
             
             __block NSManagedObjectContext* moc;

--- a/EasyMappingCoreDataExample/MappingProvider.m
+++ b/EasyMappingCoreDataExample/MappingProvider.m
@@ -16,75 +16,93 @@
 + (EKManagedObjectMapping *)carMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Car" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"carID" }];
         [mapping mapFieldsFromArray:@[@"model", @"year"]];
+        mapping.primaryKey = @"carID";
     }];
 }
 
 + (EKManagedObjectMapping *)carWithRootKeyMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Car" withRootPath:@"car" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"carID" }];
         [mapping mapFieldsFromArray:@[@"model", @"year"]];
+        mapping.primaryKey = @"carID";
     }];
 }
 
 + (EKManagedObjectMapping *)carNestedAttributesMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Car" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"carID" }];
         [mapping mapFieldsFromArray:@[@"model"]];
         [mapping mapFieldsFromDictionary:@{
             @"information.year" : @"year"
-        }];
+         }];
+        mapping.primaryKey = @"carID";
     }];
 }
 
 + (EKManagedObjectMapping *)carWithDateMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Car" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"carID" }];
         [mapping mapFieldsFromArray:@[@"model", @"year"]];
         [mapping mapKey:@"created_at" toField:@"createdAt" withDateFormat:@"yyyy-MM-dd"];
+        mapping.primaryKey = @"carID";
     }];
 }
 
 + (EKManagedObjectMapping *)phoneMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Phone" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"phoneID" }];
         [mapping mapFieldsFromArray:@[@"number"]];
         [mapping mapFieldsFromDictionary:@{
             @"ddi" : @"ddi",
             @"ddd" : @"ddd"
          }];
+        mapping.primaryKey = @"phoneID";
     }];
 }
 
 + (EKManagedObjectMapping *)personMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Person" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"personID" }];
         [mapping mapFieldsFromArray:@[@"name", @"email", @"gender"]];
         [mapping hasOneMapping:[self carMapping] forKey:@"car"];
         [mapping hasManyMapping:[self phoneMapping] forKey:@"phones"];
+        mapping.primaryKey = @"personID";
     }];
 }
 
 + (EKManagedObjectMapping *)personWithCarMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Person" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"personID" }];
         [mapping mapFieldsFromArray:@[@"name", @"email"]];
         [mapping hasOneMapping:[self carMapping] forKey:@"car"];
+        mapping.primaryKey = @"personID";
     }];
 }
 
 + (EKManagedObjectMapping *)personWithPhonesMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Person" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"personID" }];
         [mapping mapFieldsFromArray:@[@"name", @"email"]];
         [mapping hasManyMapping:[self phoneMapping] forKey:@"phones"];
+        mapping.primaryKey = @"personID";
     }];
 }
 
 + (EKManagedObjectMapping *)personWithOnlyValueBlockMapping
 {
     return [EKManagedObjectMapping mappingForEntityName:@"Person" withBlock:^(EKManagedObjectMapping *mapping) {
+        [mapping mapFieldsFromDictionary:@{ @"id": @"personID" }];
         [mapping mapFieldsFromArray:@[@"name", @"email", @"gender"]];
+        mapping.primaryKey = @"personID";
     }];
 }
 

--- a/EasyMappingCoreDataExample/Person.h
+++ b/EasyMappingCoreDataExample/Person.h
@@ -13,6 +13,7 @@
 
 @interface Person : NSManagedObject
 
+@property (nonatomic, retain) NSNumber * personID;
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSString * email;
 @property (nonatomic, retain) Car *car;

--- a/EasyMappingCoreDataExample/Person.m
+++ b/EasyMappingCoreDataExample/Person.m
@@ -12,6 +12,7 @@
 
 @implementation Person
 
+@dynamic personID;
 @dynamic name;
 @dynamic email;
 @dynamic car;

--- a/EasyMappingCoreDataExample/Phone.h
+++ b/EasyMappingCoreDataExample/Phone.h
@@ -13,6 +13,7 @@
 
 @interface Phone : NSManagedObject
 
+@property (nonatomic, retain) NSNumber * phoneID;
 @property (nonatomic, retain) NSString * ddi;
 @property (nonatomic, retain) NSString * ddd;
 @property (nonatomic, retain) NSString * number;

--- a/EasyMappingCoreDataExample/Phone.m
+++ b/EasyMappingCoreDataExample/Phone.m
@@ -12,6 +12,7 @@
 
 @implementation Phone
 
+@dynamic phoneID;
 @dynamic ddi;
 @dynamic ddd;
 @dynamic number;


### PR DESCRIPTION
This patch adds the ability of updating existing managed objects when a primary key is provided in the mapping, as opposed to creating new objects. Includes relevant spec.
