### PR TITLE
Fixed crash when representation contains date field with value [NSNull null]

### DIFF
--- a/EasyMapping/EKMapper.m
+++ b/EasyMapping/EKMapper.m
@@ -132,7 +132,12 @@
     if (fieldMapping.valueBlock) {
         value = fieldMapping.valueBlock(fieldMapping.keyPath, [representation valueForKeyPath:fieldMapping.keyPath]);
     } else if (fieldMapping.dateFormat) {
-        value = [EKTransformer transformString:[representation valueForKeyPath:fieldMapping.keyPath] withDateFormat:fieldMapping.dateFormat];
+        id tempValue = [representation valueForKeyPath:fieldMapping.keyPath];
+        if ([tempValue isKindOfClass:[NSString class]]) {
+            value = [EKTransformer transformString:tempValue withDateFormat:fieldMapping.dateFormat];
+        } else {
+            value = nil;
+        }
     } else {
         value = [representation valueForKeyPath:fieldMapping.keyPath];
     }


### PR DESCRIPTION
As described in the title, EKTransformer expects NSString for  `transformString:withDateFormat:`. EKMapper doesn't check the value contained in the representation before calling this method, leading to a crash if the value is [NSNull null].

This commit fixes this by checking if the value is an NSString. If not, nil is returned.
