### PR TITLE
Add sync array method

### DIFF
--- a/EasyMapping/EKMapper.h
+++ b/EasyMapping/EKMapper.h
@@ -19,16 +19,37 @@
                            withMapping:(EKManagedObjectMapping *)mapping
                 inManagedObjectContext:(NSManagedObjectContext*)moc;
 
-+ (id)fillObject:(id)object  fromExternalRepresentation:(NSDictionary *)externalRepresentation
-                                            withMapping:(EKObjectMapping *)mapping;
-+ (id)fillObject:(id)object  fromExternalRepresentation:(NSDictionary *)externalRepresentation
-     withMapping:(EKManagedObjectMapping *)mapping inManagedObjectContext:(NSManagedObjectContext*)moc;
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKObjectMapping *)mapping;
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKManagedObjectMapping *)mapping
+      inManagedObjectContext:(NSManagedObjectContext*)moc;
 
 
 + (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKObjectMapping *)mapping;
+
+/** Get an array of managed objects from an external representation. If the mapping has
+    a primary key existing objects will be updated. This method is slow and it doesn't
+    delete obsolete objects, use
+    syncArrayOfObjectsFromExternalRepresentation:withMapping:fetchRequest:inManagedObjectContext:
+    instead.
+ */
 + (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
                                           withMapping:(EKManagedObjectMapping *)mapping
                                inManagedObjectContext:(NSManagedObjectContext*)moc;
+
+/** Synchronize the objects in the managed obejct context with the objets from an external
+    representation. Any new objects will be created, any existing objects will be updated
+    and any object not present in the external representation will be deleted from the
+    managed object context. The fetch request is used to pre-fetch all existing objects.
+    This speeds up managed object lookup by a very significant amount.
+ */
++ (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                              withMapping:(EKManagedObjectMapping *)mapping
+                                             fetchRequest:(NSFetchRequest*)fetchRequest
+                                   inManagedObjectContext:(NSManagedObjectContext *)moc;
 
 @end


### PR DESCRIPTION
Creating an array of managed objects is really slow because for each object you have to do a lookup in the database to check if the object already exists. I added a new method to synchronize an array with the managed object context that is a lot faster and also deletes obsolete objects.
