### PR TITLE
Fix a duplicated const in EKTransformer

### DIFF
--- a/EasyMapping/EKTransformer.h
+++ b/EasyMapping/EKTransformer.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "EKFieldMapping.h"
 
-extern NSString * const EKBrazilianDefaultDateFormat;
+extern NSString * const EKRailsDefaultDatetimeFormat;
 extern NSString * const EKBrazilianDefaultDateFormat;
 
 @interface EKTransformer : NSObject


### PR DESCRIPTION
The same date format string was exposed twice and the Rails format was missing.
