### PR TITLE
Add mapping rootPath support for serialized objects

### DIFF
--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -26,6 +26,10 @@
     [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKObjectMapping *objectMapping, BOOL *stop) {
         [self setHasManyMappingObjectOn:representation withObjectMapping:objectMapping fromObject:object];
     }];
+    
+    if (mapping.rootPath.length > 0) {
+        representation = [@{mapping.rootPath : representation} mutableCopy];
+    }
     return representation;
 }
 

--- a/EasyMappingExample/EasyMappingExampleTests/EKSerializerSpec.m
+++ b/EasyMappingExample/EasyMappingExampleTests/EKSerializerSpec.m
@@ -66,6 +66,42 @@ describe(@"EKSerializer", ^{
             });
             
         });
+        
+        context(@"a simple object with root path", ^{
+            
+            __block Car *car;
+            __block NSDictionary *representation;
+            
+            beforeEach(^{
+                
+                CMFactory *factory = [CMFactory forClass:[Car class]];
+                [factory addToField:@"model" value:^{
+                    return @"i30";
+                }];
+                [factory addToField:@"year" value:^{
+                    return @"2013";
+                }];
+                car = [factory build];
+                representation = [EKSerializer serializeObject:car withMapping:[MappingProvider carWithRootKeyMapping]];
+            });
+            
+            specify(^{
+                [representation shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[representation objectForKey:@"car"] shouldNotBeNil];
+            });
+            
+            specify(^{
+                [[[[representation objectForKey:@"car"] objectForKey:@"model"] should] equal:[car.model description]];
+            });
+            
+            specify(^{
+                [[[[representation objectForKey:@"car"] objectForKey:@"year"] should] equal:[car.year description]];
+            });
+            
+        });
 
         context(@"nested keypaths", ^{
 


### PR DESCRIPTION
This allow to be able to convert back and forth using EKMapper and EKSerializer when a rootPath is used.
