### PR TITLE
Adding NSOrderedSet support for ordered relationships in CoreData

### DIFF
--- a/EasyMapping/EKMapper.m
+++ b/EasyMapping/EKMapper.m
@@ -108,8 +108,9 @@
         NSArray *arrayToBeParsed = [representation valueForKeyPath:key];
         if (arrayToBeParsed) {
             NSArray *parsedArray = [self arrayOfObjectsFromExternalRepresentation:arrayToBeParsed withMapping:obj inManagedObjectContext:moc];
+            id parsedObjects = [EKMapper convertPropertyArray:parsedArray forObject:object withPropertyName:[obj field]];
             EKObjectMapping * mapping = obj;
-            [object setValue:[NSSet setWithArray:parsedArray] forKeyPath:mapping.field];
+            [object setValue:parsedObjects forKeyPath:mapping.field];
         }
     }];
     return object;


### PR DESCRIPTION
Previously, NSSet is created for any relationship, which disallowed using hasManyMapping method for ordered relationships in CoreData. Using already existing convertPropertyArray: method seems reasonable enough here. Basically, for ordered relationships it'll use NSOrderedSet, and for unordered one's it will use NSSet.
