### PR TITLE
Add BOOL, bool to primitive values array

### DIFF
--- a/EasyMapping/EKPropertyHelper.m
+++ b/EasyMapping/EKPropertyHelper.m
@@ -10,7 +10,8 @@
 #import <objc/runtime.h>
 
 static const unichar nativeTypes[] = {
-    _C_CHR, _C_UCHR,           // BOOL, char, unsigned char
+    _C_BOOL, _C_BFLD,          // BOOL
+    _C_CHR, _C_UCHR,           // char, unsigned char
     _C_SHT, _C_USHT,           // short, unsigned short
     _C_INT, _C_UINT,           // int, unsigned int, NSInteger, NSUInteger
     _C_LNG, _C_ULNG,           // long, unsigned long


### PR DESCRIPTION
There is no boolean primitive type in the nativeTypes array, got crashes when serializing objects

![snapfinger_xcworkspace__ekpropertyhelper_m-2](https://f.cloud.github.com/assets/872907/2308971/9c9d1786-a2c8-11e3-8df0-d556054d4f4c.png)
