### PR TITLE
Primary Key mapping in Core Data Importer

### DIFF
--- a/EasyMapping/EKCoreDataImporter.h
+++ b/EasyMapping/EKCoreDataImporter.h
@@ -75,7 +75,7 @@
  
  @result managed object
  */
-- (id)existingObjectForRepresentation:(id)representation mapping:(EKManagedObjectMapping *)mapping;
+- (id)existingObjectForRepresentation:(id)representation mapping:(EKManagedObjectMapping *)mapping context:(NSManagedObjectContext *)context;
 
 - (void)cacheObject:(NSManagedObject *)object withMapping:(EKManagedObjectMapping *)mapping;
 

--- a/EasyMapping/EKManagedObjectMapper.m
+++ b/EasyMapping/EKManagedObjectMapper.m
@@ -46,7 +46,8 @@
                            withMapping:(EKManagedObjectMapping *)mapping
 {
     NSManagedObject * object = [self.importer existingObjectForRepresentation:externalRepresentation
-                                                                      mapping:mapping];
+                                                                      mapping:mapping
+                                                                      context:self.importer.context];
     if (!object)
     {
         object = [NSEntityDescription insertNewObjectForEntityForName:mapping.entityName


### PR DESCRIPTION
The Core Data Importer doesn't use the manage object mapping to get the primary key value. This causes an issue when the primary key mapping has a value block. This pull request solves this issue.
