### PR TITLE
Fix hasOne property crash

### DIFF
--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -171,7 +171,7 @@
 + (void)setValue:(id)value forKeyPath:(NSString *)keyPath inRepresentation:(NSMutableDictionary *)representation {
     NSArray *keyPathComponents = [keyPath componentsSeparatedByString:@"."];
     if ([keyPathComponents count] == 1) {
-        [representation setObject:value forKey:keyPath];
+        [representation setObject:value ?: [NSNull null] forKey:keyPath];
     } else if ([keyPathComponents count] > 1) {
         NSString *attributeKey = [keyPathComponents lastObject];
         NSMutableArray *subPaths = [NSMutableArray arrayWithArray:keyPathComponents];


### PR DESCRIPTION
Trying to make dictionary representation from Core Data object with nil property with hasOne mapping type leads to crash. Replacing nil value by [NSNull null] fix it.
