### PR TITLE
improving performance of EKCoreDataImporter

### DIFF
--- a/EasyMapping/EKCoreDataImporter.m
+++ b/EasyMapping/EKCoreDataImporter.m
@@ -109,14 +109,14 @@
     NSMutableDictionary * existingPrimaryKeys = [NSMutableDictionary dictionary];
     for (NSString * entityName in self.entityNames)
     {
-        existingPrimaryKeys[entityName] = [NSSet set];
+        existingPrimaryKeys[entityName] = [NSMutableSet set];
     }
     [self inspectRepresentation:self.externalRepresentation
                    usingMapping:self.mapping
                accumulateInside:existingPrimaryKeys
                         context:context];
 
-    self.existingEntitiesPrimaryKeys = [existingPrimaryKeys copy];
+    self.existingEntitiesPrimaryKeys = existingPrimaryKeys;
 }
 
 - (void)inspectRepresentation:(id)representation
@@ -133,7 +133,7 @@
             id value = [self primaryKeyValueFromRepresentation:objectInfo usingMapping:mapping context:context];
             if (value && value != (id)[NSNull null])
             {
-                dictionary[mapping.entityName] = [dictionary[mapping.entityName] setByAddingObject:value];
+                [(NSMutableSet *)dictionary[mapping.entityName] addObject:value];
             }
         }
     }
@@ -142,7 +142,7 @@
         id value = [self primaryKeyValueFromRepresentation:rootRepresentation usingMapping:mapping context:context];
         if (value && value != (id)[NSNull null])
         {
-            dictionary[mapping.entityName] = [dictionary[mapping.entityName] setByAddingObject:value];
+            [(NSMutableSet *)dictionary[mapping.entityName] addObject:value];
         }
     }
 


### PR DESCRIPTION
Using NSMutableSet and addObject, instead of NSSet and setByAddingObject for
accumulating existing primary keys within the import. NSSet:setByAddingObject
was creating copy of the set everytime a new primary keys was added which made
the process slow down exponentially with growing amount of primary keys.

Running the EKCoreDataImportBenchmarkSuite with howManyTimes set to 5000 used to
take around 30 seconds before the change, and after dropped just over 1 second.