### PR TITLE
Added missing ek_ in front of formatterForCurrentThread

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ typedef enum {
 {
     return [EKObjectMapping mappingForClass:self withBlock:^(EKObjectMapping *mapping) {
         [mapping mapPropertiesFromArray:@[@"model", @"year"]];
-        [mapping mapKeyPath:@"created_at" toProperty:@"createdAt" withDateFormatter:[NSDateFormatter formatterForCurrentThread]];
+        [mapping mapKeyPath:@"created_at" toProperty:@"createdAt" withDateFormatter:[NSDateFormatter ek_formatterForCurrentThread]];
     }];
 }
 


### PR DESCRIPTION
 Added missing ek_ in front of formatterForCurrentThread to make the NSDateFormatter example working again.