### PR TITLE
Adding support for conditional hasOne / hasMany mappings

### DIFF
--- a/EasyMapping/EKCoreDataImporter.m
+++ b/EasyMapping/EKCoreDataImporter.m
@@ -75,7 +75,7 @@
 {
     [entityNames addObject:mapping.entityName];
 
-    for (EKRelationshipMapping * oneMapping in [mapping.hasOneMappings allValues])
+    for (EKRelationshipMapping * oneMapping in mapping.hasOneMappings)
     {
         EKManagedObjectMapping * mapping = (EKManagedObjectMapping *)[oneMapping objectMapping];
         if ([self.collectedEntityNames containsObject:mapping.entityName])
@@ -88,7 +88,7 @@
         }
     }
 
-    for (EKRelationshipMapping * manyMapping in [mapping.hasManyMappings allValues])
+    for (EKRelationshipMapping * manyMapping in mapping.hasManyMappings)
     {
         EKManagedObjectMapping * mapping = (EKManagedObjectMapping *)[manyMapping objectMapping];
         if ([self.collectedEntityNames containsObject:mapping.entityName])
@@ -146,9 +146,9 @@
         }
     }
 
-    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * mapping, BOOL * stop)
+    for (EKRelationshipMapping *relationship in mapping.hasOneMappings)
     {
-        id oneMappingRepresentation = [rootRepresentation valueForKeyPath:key];
+        id oneMappingRepresentation = [rootRepresentation valueForKeyPath:relationship.keyPath];
         if (oneMappingRepresentation && ![oneMappingRepresentation isEqual:[NSNull null]])
         {
             // This is needed, because if one of the objects in array does not contain object for key, returned structure would be something like this:
@@ -166,15 +166,15 @@
             }
 
             [self inspectRepresentation:oneMappingRepresentation
-                           usingMapping:(EKManagedObjectMapping *)[mapping objectMapping]
+                           usingMapping:(EKManagedObjectMapping *)[relationship objectMapping]
                        accumulateInside:dictionary
                                 context:context];
         }
-    }];
+    }
 
-    [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * mapping, BOOL * stop)
+    for (EKRelationshipMapping *relationship in mapping.hasManyMappings)
     {
-        NSArray * manyMappingRepresentation = [rootRepresentation valueForKeyPath:key];
+        NSArray * manyMappingRepresentation = [rootRepresentation valueForKeyPath:relationship.keyPath];
 
         if (manyMappingRepresentation && ![manyMappingRepresentation isEqual:[NSNull null]])
         {
@@ -191,11 +191,11 @@
             }
 
             [self inspectRepresentation:manyMappingRepresentation
-                           usingMapping:(EKManagedObjectMapping *)[mapping objectMapping]
+                           usingMapping:(EKManagedObjectMapping *)[relationship objectMapping]
                        accumulateInside:dictionary
                                 context:context];
         }
-    }];
+    }
 }
 
 - (id)primaryKeyValueFromRepresentation:(id)representation usingMapping:(EKManagedObjectMapping *)mapping context:(NSManagedObjectContext *)context

--- a/EasyMapping/EKManagedObjectMapper.m
+++ b/EasyMapping/EKManagedObjectMapper.m
@@ -75,12 +75,11 @@
          respectPropertyType:mapping.respectPropertyFoundationTypes
          ignoreMissingFields:mapping.ignoreMissingFields];
     }];
-    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * relationship, BOOL * stop)
-    {
+    for (EKRelationshipMapping *relationship in mapping.hasOneMappings) {
         NSDictionary * value = [relationship extractObjectFromRepresentation:representation];
         if(mapping.ignoreMissingFields && !value)
         {
-            return;
+            continue;
         }
         if (value && value != (id)[NSNull null]) {
             id result = [self objectFromExternalRepresentation:value withMapping:(EKManagedObjectMapping *)[relationship objectMapping]];
@@ -89,13 +88,13 @@
             [EKPropertyHelper setValue:nil onObject:object forKeyPath:relationship.property];
         }
         
-    }];
-    [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * relationship, BOOL * stop)
-    {
-        NSArray * arrayToBeParsed = [representation valueForKeyPath:key];
+    }
+    
+    for (EKRelationshipMapping *relationship in mapping.hasManyMappings) {
+        NSArray * arrayToBeParsed = [representation valueForKeyPath:relationship.keyPath];
         if(mapping.ignoreMissingFields && !arrayToBeParsed)
         {
-            return;
+            continue;
         }
         
         if (arrayToBeParsed && arrayToBeParsed != (id)[NSNull null])
@@ -114,7 +113,7 @@
         } else {
             [EKPropertyHelper setValue:nil onObject:object forKeyPath:relationship.property];
         }
-    }];
+    }
     return object;
 }
 

--- a/EasyMapping/EKManagedObjectMapping.m
+++ b/EasyMapping/EKManagedObjectMapping.m
@@ -57,8 +57,8 @@
     {
         _entityName = entityName;
         _propertyMappings = [NSMutableDictionary dictionary];
-        _hasOneMappings = [NSMutableDictionary dictionary];
-        _hasManyMappings = [NSMutableDictionary dictionary];
+        _hasOneMappings = [NSMutableArray array];
+        _hasManyMappings = [NSMutableArray array];
     }
     return self;
 }

--- a/EasyMapping/EKMapper.m
+++ b/EasyMapping/EKMapper.m
@@ -54,6 +54,13 @@
                   ignoreMissingFields:mapping.ignoreMissingFields];
     }];
     [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * valueMapping, BOOL *stop) {
+        
+        if (valueMapping.condition) {
+            if (!valueMapping.condition(representation)) {
+                return;
+            }
+        }
+        
         NSDictionary * value = [valueMapping extractObjectFromRepresentation:representation];
         
         if(mapping.ignoreMissingFields  && !value)
@@ -69,7 +76,14 @@
 		 }
     }];
     [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * valueMapping, BOOL *stop) {
-		 NSArray *arrayToBeParsed = [representation valueForKeyPath:key];
+		 
+        if (valueMapping.condition) {
+            if (!valueMapping.condition(representation)) {
+                return;
+            }
+        }
+        
+        NSArray *arrayToBeParsed = [representation valueForKeyPath:key];
         if(mapping.ignoreMissingFields && !arrayToBeParsed)
         {
             return;

--- a/EasyMapping/EKMapper.m
+++ b/EasyMapping/EKMapper.m
@@ -53,11 +53,10 @@
                   respectPropertyType:mapping.respectPropertyFoundationTypes
                   ignoreMissingFields:mapping.ignoreMissingFields];
     }];
-    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * valueMapping, BOOL *stop) {
-        
+    for (EKRelationshipMapping *valueMapping in mapping.hasOneMappings) {
         if (valueMapping.condition) {
             if (!valueMapping.condition(representation)) {
-                return;
+                continue;
             }
         }
         
@@ -65,7 +64,7 @@
         
         if(mapping.ignoreMissingFields  && !value)
         {
-            return;
+            continue;
         }
         
 		 if (value && value != (id)[NSNull null]) {
@@ -74,19 +73,20 @@
 		 } else {
 			 [object setValue:nil forKey:valueMapping.property];
 		 }
-    }];
-    [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping * valueMapping, BOOL *stop) {
-		 
+    }
+    
+    for (EKRelationshipMapping *valueMapping in mapping.hasManyMappings) {
+
         if (valueMapping.condition) {
             if (!valueMapping.condition(representation)) {
-                return;
+                continue;
             }
         }
         
-        NSArray *arrayToBeParsed = [representation valueForKeyPath:key];
+        NSArray *arrayToBeParsed = [representation valueForKeyPath:valueMapping.keyPath];
         if(mapping.ignoreMissingFields && !arrayToBeParsed)
         {
-            return;
+            continue;
         }
         
 		 if (arrayToBeParsed && arrayToBeParsed != (id)[NSNull null]) {
@@ -108,7 +108,7 @@
 		 } else if(!mapping.incrementalData) {
 			 [object setValue:nil forKey:valueMapping.property];
 		 }
-    }];
+    }
     return object;
 }
 

--- a/EasyMapping/EKMappingBlocks.h
+++ b/EasyMapping/EKMappingBlocks.h
@@ -26,6 +26,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef BOOL (^EKMappingConditionBlock)(id representation);
+
 typedef _Nullable id(^EKMappingValueBlock)(NSString *key, _Nullable id value);
 typedef _Nullable id(^EKMappingReverseBlock)(_Nullable id value);
 

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -67,14 +67,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSMutableDictionary *propertyMappings;
 
 /**
- Dictionary, containing to-one relationships of current object.
+ Array, containing to-one relationships of current object.
  */
-@property (nonatomic, strong, readonly) NSMutableDictionary *hasOneMappings;
+@property (nonatomic, strong, readonly) NSMutableArray *hasOneMappings;
 
 /**
- Dictionary, containing to-many relationships of current object.
+ Array, containing to-many relationships of current object.
  */
-@property (nonatomic, strong, readonly) NSMutableDictionary *hasManyMappings;
+@property (nonatomic, strong, readonly) NSMutableArray *hasManyMappings;
 
 /**
  Convenience initializer.

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -23,6 +23,7 @@
 
 #import "EKMappingBlocks.h"
 
+@class EKRelationshipMapping;
 @protocol EKMappingProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -209,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param keyPath keyPath to child object representation in JSON
  */
-- (void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath;
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath;
 
 /**
  Map to-one relationship for keyPath. ObjectClass should conform to `EKMappingProtocol`.
@@ -220,7 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param property Name of the property, that will receive mapped object.
  */
-- (void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
 
 /**
  Map to-one relationship, using keys that are on the same level as current object. They are collected into dictionary and passed along, as like they were in separate JSON dictionary.
@@ -235,10 +236,10 @@ NS_ASSUME_NONNULL_BEGIN
  
  @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
  */
-- (void)           hasOne:(Class)objectClass
-forDictionaryFromKeyPaths:(NSArray *)keyPaths
-              forProperty:(NSString *)property
-        withObjectMapping:(nullable EKObjectMapping *)objectMapping;
+- (EKRelationshipMapping *)           hasOne:(Class)objectClass
+                   forDictionaryFromKeyPaths:(NSArray *)keyPaths
+                                 forProperty:(NSString *)property
+                           withObjectMapping:(nullable EKObjectMapping *)objectMapping;
 
 /**
  Map to-one relationship for keyPath.
@@ -251,7 +252,7 @@ forDictionaryFromKeyPaths:(NSArray *)keyPaths
  
  @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
 */
-- (void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(nullable EKObjectMapping*)objectMapping;
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(nullable EKObjectMapping*)objectMapping;
 
 
 /**
@@ -261,7 +262,7 @@ forDictionaryFromKeyPaths:(NSArray *)keyPaths
  
  @param keyPath keyPath to child object representations in JSON
  */
-- (void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath;
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath;
 
 /**
  Map to-many relationship for keyPath. ObjectClass should conform to `EKMappingProtocol`.
@@ -272,7 +273,7 @@ forDictionaryFromKeyPaths:(NSArray *)keyPaths
  
  @param property Name of the property, that will receive mapped objects.
  */
-- (void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
 
 /**
  Map to-many relationship for keyPath.
@@ -285,7 +286,7 @@ forDictionaryFromKeyPaths:(NSArray *)keyPaths
  
   @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
  */
--(void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(nullable EKObjectMapping*)objectMapping;
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(nullable EKObjectMapping*)objectMapping;
 
 @end
 

--- a/EasyMapping/EKObjectMapping.h
+++ b/EasyMapping/EKObjectMapping.h
@@ -209,6 +209,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param objectClass class for child object
  
  @param keyPath keyPath to child object representation in JSON
+ 
+ @result The created relationship mapping
  */
 - (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath;
 
@@ -220,6 +222,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param keyPath keyPath to child object representation in JSON
  
  @param property Name of the property, that will receive mapped object.
+ 
+ @result The created relationship mapping
  */
 - (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
 
@@ -233,6 +237,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param property name of the property, that will receive mapped object
  
  @param objectMapping optional mapping override for child object
+ 
+ @result The created relationship mapping
  
  @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
  */
@@ -249,6 +255,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param property Name of the property, that will receive mapped object.
 
  @param objectMapping optional mapping override for child object
+ 
+ @result The created relationship mapping
  
  @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
 */
@@ -272,6 +280,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param keyPath keyPath to child objects representation in JSON
  
  @param property Name of the property, that will receive mapped objects.
+ 
+ @result The created relationship mapping
  */
 - (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property;
 
@@ -283,6 +293,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param property Name of the property, that will receive mapped objects.
  
  @param objectMapping optional mapping override for child objects
+ 
+ @result The created relationship mapping
  
   @warning If you have recursive mappings, do not use this method, cause it can cause infinite recursion to happen. Or you need to handle recursive mappings situation by yourself, subclassing EKObjectMapping and providing different mappings for different mapping levels.
  */

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -187,17 +187,17 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     [self addPropertyMappingToDictionary:mapping];
 }
 
--(void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath
 {
-    [self hasOne:objectClass forKeyPath:keyPath forProperty:keyPath withObjectMapping:nil];
+    return [self hasOne:objectClass forKeyPath:keyPath forProperty:keyPath withObjectMapping:nil];
 }
 
--(void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property
 {
-    [self hasOne:objectClass forKeyPath:keyPath forProperty:property withObjectMapping:nil];
+    return [self hasOne:objectClass forKeyPath:keyPath forProperty:property withObjectMapping:nil];
 }
 
--(void)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(EKObjectMapping*)objectMapping
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(EKObjectMapping*)objectMapping
 {
     if (!objectMapping) {
         NSParameterAssert([objectClass conformsToProtocol:@protocol(EKMappingProtocol)] ||
@@ -213,9 +213,11 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.objectMapping = objectMapping;
     
     [self.hasOneMappings setObject:relationship forKey:keyPath];
+    
+    return relationship;
 }
 
--(void)hasOne:(Class)objectClass forDictionaryFromKeyPaths:(NSArray *)keyPaths forProperty:(NSString *)property withObjectMapping:(EKObjectMapping *)mapping
+- (EKRelationshipMapping *)hasOne:(Class)objectClass forDictionaryFromKeyPaths:(NSArray *)keyPaths forProperty:(NSString *)property withObjectMapping:(EKObjectMapping *)mapping
 {
     if (!mapping) {
         NSParameterAssert([objectClass conformsToProtocol:@protocol(EKMappingProtocol)] ||
@@ -231,19 +233,21 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.objectMapping = mapping;
     
     self.hasOneMappings[keyPaths.firstObject] = relationship;
+    
+    return relationship;
 }
 
--(void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath
 {
-    [self hasMany:objectClass forKeyPath:keyPath forProperty:keyPath withObjectMapping:nil];
+    return [self hasMany:objectClass forKeyPath:keyPath forProperty:keyPath withObjectMapping:nil];
 }
 
--(void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property
 {
-    [self hasMany:objectClass forKeyPath:keyPath forProperty:property withObjectMapping:nil];
+    return [self hasMany:objectClass forKeyPath:keyPath forProperty:property withObjectMapping:nil];
 }
 
--(void)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(EKObjectMapping*)objectMapping
+- (EKRelationshipMapping *)hasMany:(Class)objectClass forKeyPath:(NSString *)keyPath forProperty:(NSString *)property withObjectMapping:(EKObjectMapping*)objectMapping
 {
     if (!objectMapping) {
         NSParameterAssert([objectClass conformsToProtocol:@protocol(EKMappingProtocol)] ||
@@ -259,6 +263,8 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.objectMapping = objectMapping;
     
     [self.hasManyMappings setObject:relationship forKey:keyPath];
+    
+    return relationship;
 }
 
 - (void)addPropertyMappingToDictionary:(EKPropertyMapping *)propertyMapping

--- a/EasyMapping/EKObjectMapping.m
+++ b/EasyMapping/EKObjectMapping.m
@@ -56,8 +56,8 @@
     if (self) {
         _objectClass = objectClass;
         _propertyMappings = [NSMutableDictionary dictionary];
-        _hasOneMappings = [NSMutableDictionary dictionary];
-        _hasManyMappings = [NSMutableDictionary dictionary];
+        _hasOneMappings = [NSMutableArray array];
+        _hasManyMappings = [NSMutableArray array];
     }
     return self;
 }
@@ -146,14 +146,12 @@
         [self addPropertyMappingToDictionary:mappingObj.propertyMappings[key]];
     }
     
-    for (NSString *key in mappingObj.hasOneMappings) {
-        EKRelationshipMapping *mapping = mappingObj.hasOneMappings[key];
-        [self.hasOneMappings setObject:mapping forKey:mapping.keyPath];
+    for (EKRelationshipMapping *relationship in mappingObj.hasOneMappings) {
+        [self.hasOneMappings addObject:relationship];
     }
     
-    for (NSString *key in mappingObj.hasManyMappings) {
-         EKRelationshipMapping *mapping = mappingObj.hasManyMappings[key];
-        [self.hasManyMappings setObject:mapping forKey:mapping.keyPath];
+    for (EKRelationshipMapping *relationship in mappingObj.hasManyMappings) {
+        [self.hasManyMappings addObject:relationship];
     }
 }
 
@@ -212,7 +210,7 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.property = property;
     relationship.objectMapping = objectMapping;
     
-    [self.hasOneMappings setObject:relationship forKey:keyPath];
+    [self.hasOneMappings addObject:relationship];
     
     return relationship;
 }
@@ -232,7 +230,7 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.property = property;
     relationship.objectMapping = mapping;
     
-    self.hasOneMappings[keyPaths.firstObject] = relationship;
+    [self.hasOneMappings addObject:relationship];
     
     return relationship;
 }
@@ -262,7 +260,7 @@ withValueBlock:(id (^)(NSString *, id))valueBlock reverseBlock:(id (^)(id))rever
     relationship.property = property;
     relationship.objectMapping = objectMapping;
     
-    [self.hasManyMappings setObject:relationship forKey:keyPath];
+    [self.hasManyMappings addObject:relationship];
     
     return relationship;
 }

--- a/EasyMapping/EKRelationshipMapping.h
+++ b/EasyMapping/EKRelationshipMapping.h
@@ -8,6 +8,7 @@
 
 #import "EKObjectMapping.h"
 #import "EKMappingProtocol.h"
+#import "EKMappingBlocks.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) EKObjectMapping *objectMapping;
 
 @property (nonatomic, strong, nullable) NSArray * nonNestedKeyPaths;
+
+@property (nonatomic, strong) EKMappingConditionBlock condition;
 
 - (nullable NSDictionary *)extractObjectFromRepresentation:(NSDictionary *)representation;
 

--- a/EasyMapping/EKRelationshipMapping.h
+++ b/EasyMapping/EKRelationshipMapping.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSArray * nonNestedKeyPaths;
 
-@property (nonatomic, strong) EKMappingConditionBlock condition;
+@property (nonatomic, strong, nullable) EKMappingConditionBlock condition;
 
 - (nullable NSDictionary *)extractObjectFromRepresentation:(NSDictionary *)representation;
 

--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -35,14 +35,20 @@
     [mapping.propertyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKPropertyMapping *propertyMapping, BOOL *stop) {
         [self setValueOnRepresentation:representation fromObject:object withPropertyMapping:propertyMapping];
     }];
-    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping *mapping, BOOL *stop) {
-        id hasOneObject = [object valueForKey:mapping.property];
+    
+    for (EKRelationshipMapping *relationship in mapping.hasOneMappings) {
+        
+        if (![object isKindOfClass:mapping.class]) {
+            continue;
+        }
+        
+        id hasOneObject = [object valueForKey:relationship.property];
         
         if (hasOneObject) {
             NSDictionary *hasOneRepresentation = [self serializeObject:hasOneObject
-                                                           withMapping:[mapping objectMapping]];
+                                                           withMapping:[relationship objectMapping]];
             
-            if (mapping.nonNestedKeyPaths)
+            if (relationship.nonNestedKeyPaths)
             {
                 for (NSString * key in hasOneRepresentation.allKeys)
                 {
@@ -50,19 +56,25 @@
                 }
             }
             else {
-                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
+                [representation setObject:hasOneRepresentation forKey:relationship.keyPath];
             }
         }
-    }];
-    [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping *mapping, BOOL *stop) {
+    }
+    
+    for (EKRelationshipMapping *relationship in mapping.hasManyMappings) {
+
+        id hasManyObject = [object valueForKey:relationship.property];
         
-        id hasManyObject = [object valueForKey:mapping.property];
+        if (![object isKindOfClass:mapping.class]) {
+            continue;
+        }
+        
         if (hasManyObject) {
             NSArray *hasManyRepresentation = [self serializeCollection:hasManyObject
-                                                           withMapping:[mapping objectMapping]];
-            [representation setObject:hasManyRepresentation forKey:mapping.keyPath];
+                                                           withMapping:[relationship objectMapping]];
+            [representation setObject:hasManyRepresentation forKey:relationship.keyPath];
         }
-    }];
+    }
     
     if (mapping.rootPath.length > 0) {
         NSMutableDictionary *rootRepresentation = [NSMutableDictionary new];
@@ -94,15 +106,17 @@
                    withPropertyMapping:propertyMapping
                              inContext:context];
     }];
-    [mapping.hasOneMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping *mapping, BOOL *stop) {
-        id hasOneObject = [object valueForKey:mapping.property];
+    
+    for (EKRelationshipMapping *relationship in mapping.hasOneMappings) {
+        
+        id hasOneObject = [object valueForKey:relationship.property];
         
         if (hasOneObject) {
             NSDictionary *hasOneRepresentation = [self serializeObject:hasOneObject
-                                                           withMapping:(EKManagedObjectMapping *)[mapping objectMapping]
+                                                           withMapping:(EKManagedObjectMapping *)[relationship objectMapping]
                                                            fromContext:context];
             
-            if (mapping.nonNestedKeyPaths)
+            if (relationship.nonNestedKeyPaths)
             {
                 for (NSString * key in hasOneRepresentation.allKeys)
                 {
@@ -110,20 +124,21 @@
                 }
             }
             else {
-                [representation setObject:hasOneRepresentation forKey:mapping.keyPath];
+                [representation setObject:hasOneRepresentation forKey:relationship.keyPath];
             }
         }
-    }];
-    [mapping.hasManyMappings enumerateKeysAndObjectsUsingBlock:^(id key, EKRelationshipMapping *mapping, BOOL *stop) {
-        
-        id hasManyObject = [object valueForKey:mapping.property];
+    }
+    
+    for (EKRelationshipMapping *relationship in mapping.hasManyMappings) {
+
+        id hasManyObject = [object valueForKey:relationship.property];
         if (hasManyObject) {
             NSArray *hasManyRepresentation = [self serializeCollection:hasManyObject
-                                                           withMapping:(EKManagedObjectMapping *)[mapping objectMapping]
+                                                           withMapping:(EKManagedObjectMapping *)[relationship objectMapping]
                                                            fromContext:context];
-            [representation setObject:hasManyRepresentation forKey:mapping.keyPath];
+            [representation setObject:hasManyRepresentation forKey:relationship.keyPath];
         }
-    }];
+    }
     
     if (mapping.rootPath.length > 0) {
         NSMutableDictionary *rootRepresentation = [NSMutableDictionary new];

--- a/EasyMapping/EasyMapping.h
+++ b/EasyMapping/EasyMapping.h
@@ -33,3 +33,4 @@
 #import <EasyMapping/EKPropertyMapping.h>
 #import <EasyMapping/EKRelationshipMapping.h>
 #import <EasyMapping/NSDateFormatter+EasyMappingAdditions.h>
+#import <EasyMapping/EKRelationshipMapping.h>


### PR DESCRIPTION
This PR addresses the issue presented here: https://github.com/lucasmedeirosleite/EasyMapping/issues/141

By exposing the created EKRelationshipMapping object in the return value of the hasOne / hasMany methods on EKObjectMapping, adding a new "condition" block to EKRelationshipMapping that provides the current representation object and accepts a BOOL return value, and checking a given EKRelationshipMapping's condition block return value (if it has one) before using it, we can conditionally map classes to keys.

Note that the benefits of doing things this way is there is no required changes by existing clients if they update their EasyMapping implementation. Users can simply opt into this by providing condition blocks on their relationships via the returned EKRelationshipMapping objects if they want to.

In a later PR, convenience initializers for this kind of mapping can be added, but for the time being conditional mapping would now be possible doing something like this (in the objectMapping class method, for example):

```objc
+ (EKObjectMapping *)objectMapping {
    
    return [EKObjectMapping mappingForClass:self withBlock:^(EKObjectMapping *mapping) {
        
        // Conditionally map the "data" keypath to a Foo class, if the "dataType" is equal to "foo"
        EKRelationshipMapping *relationshipFoo = [mapping hasOne:[Foo class] forKeyPath:@"data"];
        relationship.condition = ^BOOL(id representation) {
            NSDictionary *dictionary = representation;
            if ([dictionary isKindOfClass:[NSDictionary class]]) {
                NSString *type = dictionary[@"dataType"];
                if ([type isKindOfClass:[NSString class]]) {
                    return [type isEqualToString:@"foo"];
                }
            }
            return NO;
        };
        
        // Conditionally map the "data" keypath to a Bar class, if the "dataType" is equal to "bar"
        EKRelationshipMapping *relationshipBar = [mapping hasOne:[Bar class] forKeyPath:@"data"];
        relationshipBar.condition = ^BOOL(id representation) {
            NSDictionary *dictionary = representation;
            if ([dictionary isKindOfClass:[NSDictionary class]]) {
                NSString *type = dictionary[@"dataType"];
                if ([type isKindOfClass:[NSString class]]) {
                    return [type isEqualToString:@"bar"];
                }
            }
            return NO;
        };
        
    }];
    
}
```

If approved, then a future PR can be made to provide simpler mechanisms for performing the same logic, eg;

```objc
+ (EKObjectMapping *)objectMapping {
    
    return [EKObjectMapping mappingForClass:self withBlock:^(EKObjectMapping *mapping) {
        
        // Conditionally map the "data" keypath to a Foo class, if the "dataType" is equal to "foo"
        EKRelationshipMapping *relationshipFoo = [mapping hasOne:[Foo class] forKeyPath:@"data"];
        relationshipFoo.condition = [EKRelationshipConditionHelper conditionIfValueForKey: @"dataType" isEqualToString: @"foo"];
        
        // Conditionally map the "data" keypath to a Bar class, if the "dataType" is equal to "bar"
        EKRelationshipMapping *relationshipBar = [mapping hasOne:[Foo class] forKeyPath:@"data"];
        relationshipBar.condition = [EKRelationshipConditionHelper conditionIfValueForKey: @"dataType" isEqualToString: @"bar"];
        
    }];
    
}
```