### PR TITLE
Fix array types for serializeCollection

### DIFF
--- a/EasyMapping/EKSerializer.h
+++ b/EasyMapping/EKSerializer.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result parsed JSON in a form of NSArray.
  */
-+ (NSArray *)serializeCollection:(NSArray<EKMappingProtocol> *)collection withMapping:(EKObjectMapping *)mapping;
++ (NSArray *)serializeCollection:(NSArray<id<EKMappingProtocol>> *)collection withMapping:(EKObjectMapping *)mapping;
 
 /**
  Convert CoreData managed object to JSON representation.
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result parsed JSON in a form of NSArray.
  */
-+ (NSArray *)serializeCollection:(NSArray<EKManagedMappingProtocol> *)collection
++ (NSArray *)serializeCollection:(NSArray<id<EKManagedMappingProtocol>> *)collection
                      withMapping:(EKManagedObjectMapping*)mapping
                      fromContext:(NSManagedObjectContext *)context;
 @end

--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -74,11 +74,11 @@
     return representation;
 }
 
-+ (NSArray *)serializeCollection:(NSArray *)collection withMapping:(EKObjectMapping *)mapping
++ (NSArray *)serializeCollection:(NSArray<id<EKMappingProtocol>> *)collection withMapping:(EKObjectMapping *)mapping
 {
     NSMutableArray *array = [NSMutableArray array];
     
-    for (id object in collection) {
+    for (id<EKMappingProtocol> object in collection) {
         NSDictionary *objectRepresentation = [self serializeObject:object withMapping:mapping];
         [array addObject:objectRepresentation];
     }
@@ -138,11 +138,11 @@
     return representation;
 }
 
-+(NSArray *)serializeCollection:(NSArray *)collection withMapping:(EKManagedObjectMapping *)mapping fromContext:(NSManagedObjectContext *)context
++(NSArray *)serializeCollection:(NSArray<id<EKManagedMappingProtocol>> *)collection withMapping:(EKManagedObjectMapping *)mapping fromContext:(NSManagedObjectContext *)context
 {
     NSMutableArray *array = [NSMutableArray array];
     
-    for (id object in collection) {
+    for (id<EKManagedMappingProtocol> object in collection) {
         NSDictionary *objectRepresentation = [self serializeObject:object withMapping:mapping fromContext:context];
         [array addObject:objectRepresentation];
     }


### PR DESCRIPTION
The `serializeCollection:` methods declare the `collection` parameter as `NSArray<EK(Managed)MappingProtocol>*` (an array that itself conforms to the protocol). I believe it's more correct as `NSArray<id<EK(Managed)MappingProtocol>>*` (an array of objects that conform to the protocol).