### PR TITLE
Add an ability to ignore a field during serialization

### DIFF
--- a/EasyMapping/EKSerializer.m
+++ b/EasyMapping/EKSerializer.m
@@ -180,7 +180,7 @@
 + (void)setValue:(id)value forKeyPath:(NSString *)keyPath inRepresentation:(NSMutableDictionary *)representation {
     NSArray *keyPathComponents = [keyPath componentsSeparatedByString:@"."];
     if ([keyPathComponents count] == 1) {
-        [representation setObject:value forKey:keyPath];
+        representation[keyPath] = value;
     } else if ([keyPathComponents count] > 1) {
         NSString *attributeKey = [keyPathComponents lastObject];
         NSMutableArray *subPaths = [NSMutableArray arrayWithArray:keyPathComponents];

--- a/EasyMappingExample/Classes/Providers/MappingProvider.h
+++ b/EasyMappingExample/Classes/Providers/MappingProvider.h
@@ -26,6 +26,7 @@
 + (EKObjectMapping *)nativeMappingWithNullPropertie;
 + (EKObjectMapping *)personMappingThatAssertsOnNilInValueBlock;
 + (EKObjectMapping *)personWithPetsMapping;
++ (EKObjectMapping *)personMappingThatIgnoresSocialUrlDuringSerialization;
 
 + (NSDateFormatter *)iso8601DateFormatter;
 

--- a/EasyMappingExample/Classes/Providers/MappingProvider.m
+++ b/EasyMappingExample/Classes/Providers/MappingProvider.m
@@ -218,4 +218,13 @@
     return mapping;
 }
 
++(EKObjectMapping *)personMappingThatIgnoresSocialUrlDuringSerialization
+{
+    EKObjectMapping *mapping = [self personMapping];
+    [mapping mapKeyPath:@"socialURL" toProperty:@"socialURL"
+         withValueBlock:[EKMappingBlocks urlMappingBlock]
+           reverseBlock:^id _Nullable(id  _Nullable value) { return nil; }];
+    return mapping;
+}
+
 @end

--- a/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
@@ -189,31 +189,71 @@ describe(@"EKSerializer", ^{
            
             __block Person *person;
             __block NSDictionary *representation;
-            
+
+            beforeEach(^{
+
+                CMFactory *factory = [CMFactory forClass:[Person class]];
+                [factory addToField:@"name" value:^{
+                    return @"Lucas";
+                }];
+                [factory addToField:@"email" value:^{
+                    return @"lucastoc@gmail.com";
+                }];
+                [factory addToField:@"gender" value:^{
+                    return @(GenderMale);
+                }];
+                [factory addToField:@"socialURL" value:^id{
+                    return [NSURL URLWithString:@"https://www.twitter.com/EasyMapping"];
+                }];
+                person = [factory build];
+
+            });
+
             context(@"using EKMappingBlocks", ^{
-                person = [Person new];
-                person.socialURL = [NSURL URLWithString:@"https://www.twitter.com/EasyMapping"];
-                
-                representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
-                
-                [[representation[@"socialURL"] should] equal:@"https://www.twitter.com/EasyMapping"];
+                beforeEach(^{
+                    representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
+                });
+
+                specify(^{
+                    [representation shouldNotBeNil];
+                });
+
+                specify(^{
+                    [representation[@"socialURL"] shouldNotBeNil];
+                });
+
+                specify(^{
+                    [[representation[@"socialURL"] should] equal:@"https://www.twitter.com/EasyMapping"];
+                });
             });
             
             context(@"using mapping blocks with nil value", ^{
-                person = [Person new];
-                person.socialURL = nil;
-                
-                representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
 
-                [[representation[@"socialURL"] should] equal:[NSNull null]];
+                beforeEach(^{
+                    person.socialURL = nil;
+                    representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
+                });
+
+                specify(^{
+                    [representation shouldNotBeNil];
+                });
+
+                specify(^{
+                    [representation[@"socialURL"] shouldBeNil];
+                });
+
             });
 
             context(@"ignoring socialURL property during serialization to NSDictionary", ^{
-                person = [Person new];
-                person.socialURL = [NSURL URLWithString:@"https://www.twitter.com/EasyMapping"];
 
-                EKObjectMapping *mapping = [MappingProvider personMappingThatIgnoresSocialUrlDuringSerialization];
-                representation = [EKSerializer serializeObject:person withMapping:mapping];
+                beforeEach(^{
+                    EKObjectMapping *mapping = [MappingProvider personMappingThatIgnoresSocialUrlDuringSerialization];
+                    representation = [EKSerializer serializeObject:person withMapping:mapping];
+                });
+
+                specify(^{
+                    [representation shouldNotBeNil];
+                });
 
                 specify(^{
                     [representation[@"socialURL"] shouldBeNil];
@@ -223,22 +263,9 @@ describe(@"EKSerializer", ^{
             context(@"when male", ^{
                 
                 beforeEach(^{
-                    
-                    CMFactory *factory = [CMFactory forClass:[Person class]];
-                    [factory addToField:@"name" value:^{
-                        return @"Lucas";
-                    }];
-                    [factory addToField:@"email" value:^{
-                        return @"lucastoc@gmail.com";
-                    }];
-                    [factory addToField:@"gender" value:^{
-                        return @(GenderMale);
-                    }];
-                    person = [factory build];
                     representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personWithOnlyValueBlockMapping]];
-                    
                 });
-                
+
                 specify(^{
                     [representation shouldNotBeNil];
                 });

--- a/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
@@ -476,47 +476,45 @@ describe(@"EKSerializer", ^{
             });
                         
         });
-		 
-		 context(@"with hasOneRelation NULL", ^{
-			 __block Person * person;
-			 __block NSDictionary * representation;
-			 
-			 beforeEach(^{
-				 NSDictionary* externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithNullCar"];
-				 person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
-				 representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
-			 });
-			 
-			 specify(^{
-				 [[[representation objectForKey:@"phones"] shouldNot] beNil];
-			 });
-			 
-			 specify(^{
-				 [[[representation objectForKey:@"car"] should] beNil];
-			 });
-		 });
-		 
-		 
-		 context(@"with hasManyRelation NULL", ^{
-			 __block Person * person;
-			 __block NSDictionary * representation;
-			 
-			 beforeEach(^{
-				 NSDictionary* externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithNullPhones"];
-				 person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
-				 representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
-			 });
-			 
-			 specify(^{
-				 [[[representation objectForKey:@"phones"] should] beNil];
-			 });
-			 
-			 specify(^{
-				 [[[representation objectForKey:@"car"] shouldNot] beNil];
-			 });
-		 });
-		 
-        
+
+        context(@"with hasOneRelation NULL", ^{
+            __block Person * person;
+            __block NSDictionary * representation;
+
+            beforeEach(^{
+                NSDictionary* externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithNullCar"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
+            });
+
+            specify(^{
+                [[[representation objectForKey:@"phones"] shouldNot] beNil];
+            });
+
+            specify(^{
+                [[[representation objectForKey:@"car"] should] beNil];
+            });
+        });
+
+        context(@"with hasManyRelation NULL", ^{
+            __block Person * person;
+            __block NSDictionary * representation;
+
+            beforeEach(^{
+                NSDictionary* externalRepresentation = [CMFixture buildUsingFixture:@"PersonWithNullPhones"];
+                person = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[MappingProvider personMapping]];
+                representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
+            });
+
+            specify(^{
+                [[[representation objectForKey:@"phones"] should] beNil];
+            });
+
+            specify(^{
+                [[[representation objectForKey:@"car"] shouldNot] beNil];
+            });
+        });
+
         context(@"with native properties", ^{
             
             __block Native *native;
@@ -598,50 +596,50 @@ describe(@"EKSerializer", ^{
             });
             
         });
-        
+
         context(@"with native properties in superclass", ^{
-            
+
             __block NativeChild *nativeChild;
             __block NSDictionary *representation;
-            
+
             beforeEach(^{
                 NSDictionary *externalRepresentation = [CMFixture buildUsingFixture:@"NativeChild"];
                 nativeChild = [EKMapper objectFromExternalRepresentation:externalRepresentation withMapping:[NativeChild objectMapping]];
                 representation = [EKSerializer serializeObject:nativeChild withMapping:[NativeChild objectMapping]];
             });
-            
+
             specify(^{
                 [[[representation objectForKey:@"intProperty"] should] equal:@(777)];
             });
-            
+
             specify(^{
                 [[[representation objectForKey:@"boolProperty"] should] equal:@(YES)];
             });
-            
+
             specify(^{
                 [[[representation objectForKey:@"childProperty"] should] equal:@"Hello"];
             });
-            
+
         });
-        
+
     });
-    
+
     describe(@"CoreData reverse mapping blocks", ^{
-        
+
         beforeEach(^{
             [MagicalRecord setDefaultModelFromClass:[self class]];
             [MagicalRecord setupCoreDataStackWithInMemoryStore];
         });
-        
+
         context(@"object", ^{
-            
+
             __block ManagedPerson * person = nil;
             __block NSDictionary * representation = nil;
-            
+
             beforeEach(^{
                 NSDictionary * info = [CMFixture buildUsingFixture:@"Person"];
                 NSManagedObjectContext * context = [NSManagedObjectContext MR_defaultContext];
-                
+
                 person = [EKManagedObjectMapper objectFromExternalRepresentation:info
                                                                      withMapping:[ManagedMappingProvider personWithReverseBlocksMapping]
                                                           inManagedObjectContext:context];
@@ -649,41 +647,41 @@ describe(@"EKSerializer", ^{
                                                    withMapping:[ManagedMappingProvider personWithReverseBlocksMapping]
                                                    fromContext:context];
             });
-            
+
             specify(^{
                 [[person.gender should] equal:@"husband"];
                 [[[representation objectForKey:@"gender"] should] equal:@"male"];
             });
         });
     });
-    
+
     context(@"Serialize non nested objects",^{
-        
+
         __block Person * person = nil;
         __block NSDictionary * representation = nil;
-        
+
         beforeEach(^{
             NSDictionary * info = [CMFixture buildUsingFixture:@"Person"];
-            
+
             person = [EKMapper objectFromExternalRepresentation:info
                                                     withMapping:[MappingProvider personMapping]];
             representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personNonNestedMapping]];
         });
-        
+
         specify( ^{
             [[[representation objectForKey:@"carId"] should] equal:@3];
             [[[representation objectForKey:@"carModel"] should] equal:@"i30"];
             [[[representation objectForKey:@"carYear"] should] equal:@"2013"];
         });
-        
+
         specify( ^{
             [[[representation objectForKey:@"name"] should] equal:@"Lucas"];
             [[[representation objectForKey:@"email"] should] equal:@"lucastoc@gmail.com"];
             [[[representation objectForKey:@"gender"] should] equal:@"male"];
         });
-        
+
     });
-    
+
 });
 
 SPEC_END

--- a/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
+++ b/EasyMappingExample/Tests/Specs/EKSerializerSpec.m
@@ -204,8 +204,20 @@ describe(@"EKSerializer", ^{
                 person.socialURL = nil;
                 
                 representation = [EKSerializer serializeObject:person withMapping:[MappingProvider personMapping]];
-                
+
                 [[representation[@"socialURL"] should] equal:[NSNull null]];
+            });
+
+            context(@"ignoring socialURL property during serialization to NSDictionary", ^{
+                person = [Person new];
+                person.socialURL = [NSURL URLWithString:@"https://www.twitter.com/EasyMapping"];
+
+                EKObjectMapping *mapping = [MappingProvider personMappingThatIgnoresSocialUrlDuringSerialization];
+                representation = [EKSerializer serializeObject:person withMapping:mapping];
+
+                specify(^{
+                    [representation[@"socialURL"] shouldBeNil];
+                });
             });
             
             context(@"when male", ^{


### PR DESCRIPTION
Currently returning `nil` from the field's reverse block causes an exception
because of using `setObject:` syntax for NSDictionary (can't have `nil`
in collections). This makes impossible to ignore a field in the
serialization representation:

```
[mapping mapKeyPath:@"ip" toProperty:@"ipAddress"
     withValueBlock:^id(NSString *key, id value) {
    return value;
} reverseBlock:^id(id value) {
    return nil; //causes an exception later
}];
```
This fix makes the code above work as expected: the keyPath will be
ignored during `[EKSerializer serializeObject:self
withMapping:mapping];`