### PR TITLE
Remove overly strict and unneeded type restrictions. Fixes #164

### DIFF
--- a/Sources/EasyMapping/EKManagedObjectMapper.h
+++ b/Sources/EasyMapping/EKManagedObjectMapper.h
@@ -60,10 +60,11 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result filled managed object
  */
-+ (id<EKManagedMappingProtocol>)fillObject:(id<EKManagedMappingProtocol>)object
-                fromExternalRepresentation:(NSDictionary *)externalRepresentation
-                               withMapping:(EKManagedObjectMapping *)mapping
-                    inManagedObjectContext:(NSManagedObjectContext*)context;
+                
++ (id)            fillObject:(id)object
+  fromExternalRepresentation:(NSDictionary *)externalRepresentation
+                 withMapping:(EKManagedObjectMapping *)mapping
+      inManagedObjectContext:(NSManagedObjectContext*)context;
 
 /**
  Create array of CoreData objects. If passed JSON contains primary keys, previously existing object with these keys will be updated. Simply put, this method uses Find-Or-Create pattern.
@@ -76,9 +77,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result array of managed objects
  */
-+ (NSArray<EKManagedMappingProtocol> *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
-                                                                    withMapping:(EKManagedObjectMapping *)mapping
-                                                         inManagedObjectContext:(NSManagedObjectContext*)context;
++ (NSArray *)arrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                          withMapping:(EKManagedObjectMapping *)mapping
+                               inManagedObjectContext:(NSManagedObjectContext*)context;
 
 /** 
  Synchronize the objects in the managed object context with the objects from an external
@@ -96,10 +97,10 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result array of managed objects
  */
-+ (NSArray<EKManagedMappingProtocol> *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
-                                                                        withMapping:(EKManagedObjectMapping *)mapping
-                                                                       fetchRequest:(NSFetchRequest*)fetchRequest
-                                                             inManagedObjectContext:(NSManagedObjectContext *)context;
++ (NSArray *)syncArrayOfObjectsFromExternalRepresentation:(NSArray *)externalRepresentation
+                                              withMapping:(EKManagedObjectMapping *)mapping
+                                             fetchRequest:(NSFetchRequest*)fetchRequest
+                                   inManagedObjectContext:(NSManagedObjectContext *)context;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/EasyMapping/EKMapper.h
+++ b/Sources/EasyMapping/EKMapper.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @result filled object
  */
-+ (id)            fillObject:(id<EKMappingProtocol>)object
++ (id)            fillObject:(id)object
   fromExternalRepresentation:(NSDictionary *)externalRepresentation
                  withMapping:(EKObjectMapping *)mapping;
 

--- a/Sources/EasyMapping/EKPropertyHelper.h
+++ b/Sources/EasyMapping/EKPropertyHelper.h
@@ -39,13 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable id)propertyRepresentation:(NSArray *)array forObject:(id)object withPropertyName:(NSString *)propertyName;
 
 + (void)  setProperty:(EKPropertyMapping *)propertyMapping
-             onObject:(id<EKMappingProtocol>)object
+             onObject:(id)object
    fromRepresentation:(NSDictionary *)representation
   respectPropertyType:(BOOL)respectPropertyType
  ignoreMissingFields:(BOOL)ignoreMissingFields;
 
 + (void) setProperty:(EKPropertyMapping *)propertyMapping
-            onObject:(id<EKManagedMappingProtocol>)object
+            onObject:(id)object
   fromRepresentation:(NSDictionary *)representation
            inContext:(NSManagedObjectContext *)context
  respectPropertyType:(BOOL)respectPropertyType

--- a/Sources/EasyMapping/EKSerializer.m
+++ b/Sources/EasyMapping/EKSerializer.m
@@ -137,11 +137,11 @@
     return representation;
 }
 
-+(NSArray *)serializeCollection:(NSArray<id<EKManagedMappingProtocol>> *)collection withMapping:(EKManagedObjectMapping *)mapping fromContext:(NSManagedObjectContext *)context
++(NSArray *)serializeCollection:(NSArray *)collection withMapping:(EKManagedObjectMapping *)mapping fromContext:(NSManagedObjectContext *)context
 {
     NSMutableArray *array = [NSMutableArray array];
     
-    for (id<EKManagedMappingProtocol> object in collection) {
+    for (id object in collection) {
         NSDictionary *objectRepresentation = [self serializeObject:object withMapping:mapping fromContext:context];
         [array addObject:objectRepresentation];
     }


### PR DESCRIPTION
As discussed in #164 I removed the unneeded `<EK[Managed]MappingProtocol>` type specifications.