### PR TITLE
EKSerializer now uses mapping from relationship

### DIFF
--- a/Sources/EasyMapping/EKSerializer.m
+++ b/Sources/EasyMapping/EKSerializer.m
@@ -61,7 +61,7 @@
         id hasManyObject = [object valueForKey:relationship.property];
         if (hasManyObject) {
             NSArray *hasManyRepresentation = [self serializeCollection:hasManyObject
-                                                           withMapping:[[relationship objectClass] objectMapping]];
+                                                           withMapping:[relationship mappingForObject:hasManyObject]];
             [representation setObject:hasManyRepresentation forKey:relationship.keyPath];
         }
     }


### PR DESCRIPTION
... instead of objectMaping hasManyMappings.

I had to do this to make nested custom mappings working again after updating to the latest version.
My Question object does not have an objectMapping by itself.

Example:
```
+ (EKManagedObjectMapping *)activityMapping {
    return [EKManagedObjectMapping mappingForEntityName:NSStringFromClass([Activity class]) withBlock:^(EKManagedObjectMapping *mapping)
            {
              [mapping mapPropertiesFromDictionary:@{@"UUID" : @"uuid"}];
              [mapping hasMany:[Question class]
                      forKeyPath:@"HasQuestions"
                     forProperty:@"hasQuestions"
               withObjectMapping:[self questionMapping]
              ];
             }];
}

+ (EKManagedObjectMapping *)questionMapping {
    return [EKManagedObjectMapping mappingForEntityName:NSStringFromClass([Question class]) withBlock:^(EKManagedObjectMapping *mapping)
            {
              [mapping mapPropertiesFromDictionary:@{@"UUID" : @"uuid"}];
            }];
}
```